### PR TITLE
fix argument error in index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # magnet-link changelog
 
-## [Unreleased][unreleased]
+## [1.0.1] - 2015-01-28
 * use [standard](https://github.com/feross/standard) for npm test
 * use [fixpack](https://github.com/henrikjoreteg/fixpack) for true insanity
 * add `.travis.yml`
+* add tests
+* fix a rather serious error in index
 
 ## 1.0.0 - 2015-01-23
 * first!
 
-[Unreleased]: https://github.com/ngoldman/magnet-link/compare/v1.0.0...HEAD
+[1.0.1]: https://github.com/ngoldman/magnet-link/compare/v1.0.0...v1.0.1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # magnet-link
 
+![](https://travis-ci.org/ngoldman/magnet-link.svg)
+
 Get a magnet from a torrent file.
 
 ```

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var readTorrent = require('read-torrent')
 
 module.exports = function (torrent, callback) {
-  readTorrent(process.argv[2], function (err, torrent) {
+  readTorrent(torrent, function (err, torrent) {
     if (err) return callback(err)
     if (!torrent.infoHash) return callback(new Error('Missing info hash'))
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "magnet-link",
   "description": "Get a magnet link from a torrent file.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Nate Goldman <nate@ngoldman.me>",
   "bin": {
     "magnet-link": "./cli.js"
@@ -13,7 +13,8 @@
     "read-torrent": "^1.2.0"
   },
   "devDependencies": {
-    "standard": "^2.0.0"
+    "standard": "^2.0.0",
+    "tape": "^3.4.0"
   },
   "license": "ISC",
   "main": "index.js",
@@ -22,6 +23,6 @@
     "url": "https://github.com/ngoldman/magnet-link.git"
   },
   "scripts": {
-    "test": "node node_modules/standard/bin/cmd.js"
+    "test": "node node_modules/standard/bin/cmd.js && node scripts/test.js"
   }
 }

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,0 +1,11 @@
+var test = require('tape')
+var magnetLink = require('../')
+var url = 'http://torcache.net/torrent/EF330B39F4801D25B4245212E75A38634BFC856E.torrent'
+
+test('convert url to magnet link', function (t) {
+  magnetLink(url, function (err, link) {
+    if (err) { throw err }
+    t.equal(link, 'magnet:?xt=urn:btih:ef330b39f4801d25b4245212e75a38634bfc856e')
+    t.end()
+  })
+})


### PR DESCRIPTION
Bumping to v1.0.1 -- found a pretty serious oversight in `index.js`. This fix will make the module work when using `require('magnet-link')` (current setup only works as cli).
